### PR TITLE
Support windows

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -1,0 +1,27 @@
+name: Compile Sysimage
+on: push
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1.3
+      - uses: actions/checkout@v2
+      - name: Compile
+        run: julia --project -e '
+               using Pkg;
+               Pkg.add("PackageCompiler");
+               using PackageCompiler;
+               create_sysimage(
+                   :SodiumSeal;
+                   sysimage_path="sys.so",
+                   precompile_execution_file="precompile.jl",
+               );'
+      - name: Test
+        run: julia -Jsys.so --project -e 'using Pkg; Pkg.test()'

--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -7,6 +7,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: julia-actions/setup-julia@v1
@@ -14,7 +15,8 @@ jobs:
           version: 1.3
       - uses: actions/checkout@v2
       - name: Compile
-        run: julia --project -e '
+        run: |
+            julia --project -e '
                using Pkg;
                Pkg.add("PackageCompiler");
                using PackageCompiler;
@@ -23,5 +25,7 @@ jobs:
                    sysimage_path="sys.so",
                    precompile_execution_file="precompile.jl",
                );'
+        shell: bash
       - name: Test
         run: julia -Jsys.so --project -e 'using Pkg; Pkg.test()'
+        shell: bash

--- a/precompile.jl
+++ b/precompile.jl
@@ -1,0 +1,12 @@
+using Base64: base64encode
+using SodiumSeal: KeyPair, seal, unseal
+
+k = KeyPair()
+KeyPair(k.public)
+KeyPair(base64encode(k.public))
+KeyPair(k.public, k.secret)
+KeyPair(base64encode(k.public), base64encode(k.secret))
+
+s = "hello"
+unseal(seal(Vector{UInt8}(s), k), k)
+unseal(seal(base64encode(s), k), k)


### PR DESCRIPTION
Your prblem It is about escaping the parameters in the script and shell. @Chris de Graaf

Example: https://github.com/aminya/Example.jl/blob/ea30404ca5bc6a391eaffb65d7cc3c1a0e6341c7/.github/workflows/SnoopCompileMulti.yml#L24
You can use `shell:pwsh` too (on all OS), but you need to escape all the `"` using `\` for that